### PR TITLE
Increased the TTL of ping command to prevent false "TTL exceeded" responses

### DIFF
--- a/lib/SamsungRemote.js
+++ b/lib/SamsungRemote.js
@@ -41,7 +41,7 @@ module.exports = class SamsungRemote {
             if (this.sleepMode !== null && !getRealStatus) { resolve(false); }
 
             // Check if host is online
-            exec(`ping -t 1 -c 1 ${this.ip}`, (error, stdout, stderr) => {
+            exec(`ping -t 3 -c 1 ${this.ip}`, (error, stdout, stderr) => {
                 // Debug
                 this.device.debug(stdout || stderr);
 


### PR DESCRIPTION
Was having an issue that whenever the `ping` command was executed, I was getting the following response:

```
PING 192.168.1.2 (192.168.1.2) 56(84) bytes of data.
From 192.168.1.2 icmp_seq=1 Time to live exceeded

--- 192.168.1.2 ping statistics ---
1 packets transmitted, 0 received, +1 errors, 100% packet loss, time 0ms

```

I believe this may have something to do with the fact that the Raspberry Pi running homebridge has access to a main data VLAN (1) and an IOT VLAN and the TV is connected to the IOT VLAN.

Upping `ping`'s TTL by 2 seems to have fixed the problem and may fix future issues for people that have a similar setup.