### PR TITLE
Fix WOL for Samsung K Series (2016) by updating the wake_on_lan depen…

### DIFF
--- a/lib/SamsungRemote.js
+++ b/lib/SamsungRemote.js
@@ -87,7 +87,7 @@ module.exports = class SamsungRemote {
             }
 
             // TV is OFF and we need to use WOL
-            wol.wake(this.mac, (error) => {
+            wol.wake(this.mac, {address:this.ip}, (error) => {
                 if (error) {
                     return reject('Failed to power on TV');
                 } else {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "request": "^2.88.0",
-    "wake_on_lan": "0.0.4",
+    "wake_on_lan": "^1.0.0",
     "ws": "^5.1.0"
   }
 }


### PR DESCRIPTION
Turns out updating to the latest version of the [wake_on_lan](https://www.npmjs.com/package/wake_on_lan) and adding the TV's IP address fixes the non-working K series WOL :)