### PR TITLE
fix(switch): change default switch name to: device name switch name

### DIFF
--- a/lib/accessories/switch.js
+++ b/lib/accessories/switch.js
@@ -14,11 +14,11 @@ module.exports = class Switch {
         this.device   = device;
         this.config   = config;
         this.type     = 'switch';
-        this.UUID     = Homebridge.hap.uuid.generate(this.device.UUID + this.config.identifier + this.config.name)
+        this.UUID     = Homebridge.hap.uuid.generate(this.device.UUID + this.config.name + this.config.identifier)
 
         this.services = {};
 
-        this.platformAccessory = Platform.cachedAccessories.find(cachedAccessory => cachedAccessory.UUID == this.UUID) || new Homebridge.platformAccessory(`${this.config.name} ${this.device.config.name}`, this.UUID);
+        this.platformAccessory = Platform.cachedAccessories.find(cachedAccessory => cachedAccessory.UUID == this.UUID) || new Homebridge.platformAccessory(`${this.device.config.name} ${this.config.name}`, this.UUID);
         this.platformAccessory.reachable = true;
 
         this.createServices();

--- a/lib/accessories/switch.js
+++ b/lib/accessories/switch.js
@@ -14,7 +14,7 @@ module.exports = class Switch {
         this.device   = device;
         this.config   = config;
         this.type     = 'switch';
-        this.UUID     = Homebridge.hap.uuid.generate(this.device.UUID + this.config.name + this.config.identifier)
+        this.UUID     = Homebridge.hap.uuid.generate(this.device.UUID + this.config.identifier + this.config.name)
 
         this.services = {};
 

--- a/lib/services/switch.js
+++ b/lib/services/switch.js
@@ -16,7 +16,7 @@ module.exports = class Switch {
     }
 
     createService() {
-        this.service = this.service || new Hap.Service.Switch(`${this.accessory.config.name} ${this.device.config.name}`, `switch_${this.accessory.config.identifier}`);
+        this.service = this.service || new Hap.Service.Switch(`${this.device.config.name} ${this.accessory.config.name}`, `switch_${this.accessory.config.identifier}`);
 
         this.service.getCharacteristic(Hap.Characteristic.On)
             .on('get', this.getSwitch.bind(this))


### PR DESCRIPTION
Just switched to a raspberry pi 4 and noticed this odd issue. In my case, my TV is configured as `Living Room TV`.
By putting into a room called 'Living Room' in the Home app, the switches would be called:
`Living Room Switch Living Room TV`.

This changes that so it will be called 'Living Room TV Switch' and correctly show up with Living Room on the first line and `TV Switch` on the second.

If this breaks your setup, I could make this a config option like `switchNames` with options of `device switch` or `switch device` or something, and default it to the old way.