### PR TITLE
fix(app-launch): change all apps to launch via DEEP_LINK, NATIVE_LAUNCH does not seem to work

### DIFF
--- a/lib/methods/ws.js
+++ b/lib/methods/ws.js
@@ -62,7 +62,7 @@ module.exports = class WebSocket extends BaseMethod {
                 to    : 'host',
                 event : 'ed.apps.launch',
                 data  : {
-                    action_type : application.app_type == 2 ? 'DEEP_LINK' : 'NATIVE_LAUNCH',
+                    action_type : 'DEEP_LINK',
                     appId       : application.appId
                 }
             }


### PR DESCRIPTION
Fixes #100 
Closes #168 
Stops the need for https://github.com/nicholasrobinson/homebridge-cmd4-samsung-tizen-appletv

So, from what I can tell, there are only a few apps that report as app_type 1 all work with this change:
Apple TV
Universal Guide
SmartThings

app_type 4 org.tizen.browser also works with this change