### PR TITLE
Fix/easier app list

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -14,6 +14,7 @@
     "platforms": [
         {
             "platform": "SamsungTizen",
+            "app_list": false,
             "devices": [
                 {
                     "name": "Bedroom TV",
@@ -28,6 +29,23 @@
                         {"name": "Command 3", "command": ["KEY_VOLUP", "KEY_VOLDOWN"]},
                         {"name": "Command 4", "command": ["KEY_VOLUP*5", "KEY_VOLDOWN*3"]},
                         {"name": "All", "sleep": 60, "mute": true, "command": ["KEY_VOLUP", "KEY_VOLDOWN"], "channel": 13}
+                    ],
+                    "inputs": [
+                        {
+                            "name": "Netflix",
+                            "type": "app",
+                            "value": "11101200001"
+                        },
+                        {
+                            "name": "VUDU",
+                            "type": "app",
+                            "value": "111012010001"
+                        },
+                        {
+                            "name": "YouTube",
+                            "type": "app",
+                            "value": "111299001912"
+                        }
                     ]
                 }
             ]

--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ class SamsungPlatform {
             switches : config.switches || [],
             method   : config.method || 'wss',
             refresh  : config.refresh,
-            timeout  : config.timeout
+            timeout  : config.timeout,
+            app_list : config.app_list || false,
         };
 
         if (this.api) {

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -187,7 +187,7 @@ module.exports = class Remote {
     }
 
     _installedApplications() {
-        if (process.argv.indexOf('tizen-apps') == -1) { return; }
+        if (process.argv.indexOf('tizen-apps') == -1 && !this.device.config.app_list) { return; }
 
         this.api.getApplications().then(applications => {
             console.log(this.device.config.name);


### PR DESCRIPTION
Many issues and reddit requests for app ids could be prevented by making getting the app list with ids easier for those that use hoobs or may not know their way around the command line.

Also updating config sample with the inputs block, although this plugin is in desperate need for config.schema.json file for https://github.com/oznu/homebridge-config-ui-x since it's recommended by homebridge now. I'll work on that soon and put up a PR.

Also, be sure to add this "app_list" config item to the wiki: https://github.com/tavicu/homebridge-samsung-tizen/wiki/Applications