### PR TITLE
Revert "Bump node-fetch from 2.6.1 to 3.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "delay": "^5.0.0",
         "fs-extra": "^10.0.0",
         "is-port-reachable": "^3.0.0",
-        "node-fetch": "^3.0.0",
+        "node-fetch": "^2.6.1",
         "wakeonlan": "^0.1.0",
         "ws": "^8.2.3"
       },
@@ -23,14 +23,6 @@
       "funding": {
         "type": "paypal",
         "url": "https://www.paypal.com/donate?hosted_button_id=5QLCDRNH77Z9L"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/deepmerge": {
@@ -50,27 +42,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
-      "integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fs-extra": {
@@ -109,19 +80,11 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
-      "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
-      "dependencies": {
-        "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^3.1.2"
-      },
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+        "node": "4.x || >=6.0.0"
       }
     },
     "node_modules/universalify": {
@@ -136,14 +99,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/wakeonlan/-/wakeonlan-0.1.0.tgz",
       "integrity": "sha1-t55zu6hNfSjZo1eV7wILnuzDKiU="
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
-      "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q==",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/ws": {
       "version": "8.2.3",
@@ -167,11 +122,6 @@
     }
   },
   "dependencies": {
-    "data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
-    },
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -181,14 +131,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
       "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw=="
-    },
-    "fetch-blob": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
-      "integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
-      "requires": {
-        "web-streams-polyfill": "^3.0.3"
-      }
     },
     "fs-extra": {
       "version": "10.0.0",
@@ -220,13 +162,9 @@
       }
     },
     "node-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
-      "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
-      "requires": {
-        "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^3.1.2"
-      }
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "universalify": {
       "version": "2.0.0",
@@ -237,11 +175,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/wakeonlan/-/wakeonlan-0.1.0.tgz",
       "integrity": "sha1-t55zu6hNfSjZo1eV7wILnuzDKiU="
-    },
-    "web-streams-polyfill": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
-      "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q=="
     },
     "ws": {
       "version": "8.2.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "delay": "^5.0.0",
     "fs-extra": "^10.0.0",
     "is-port-reachable": "^3.0.0",
-    "node-fetch": "^3.0.0",
+    "node-fetch": "^2.6.1",
     "wakeonlan": "^0.1.0",
     "ws": "^8.2.3"
   },


### PR DESCRIPTION
Reverts tavicu/homebridge-samsung-tizen#405