### PR TITLE
Add Max to list of known applications

### DIFF
--- a/docs/extra/applications.md
+++ b/docs/extra/applications.md
@@ -20,6 +20,7 @@ Most of the IDs changed starting with year 2020. If you know your TV model is fr
 | HBO GO                   | `3201706012478`                                     |
 | HBO GO Asia              | `3202004020575`                                     |
 | HBO Max                  | `3201601007230`                                     |
+| Max                      | `3202301029760`                                     |
 | Hulu                     | `3201601007625`                                     |
 | Plex                     | `3201512006963` / `3201512006963`                   |
 | Prime Video              | `3201512006785` / `3201910019365`                   |


### PR DESCRIPTION
Max is the successor app to HBO Max. Tested with Home app on iOS after configuring Tizen plugin.
<img width="431" alt="Max" src="https://github.com/tavicu/homebridge-samsung-tizen/assets/2432250/74541ac7-0de5-4091-8cb0-823572618e4e">
