### PR TITLE
Added popular German TV app-ids to documentation

### DIFF
--- a/docs/extra/applications.md
+++ b/docs/extra/applications.md
@@ -144,6 +144,15 @@ Most of the IDs changed starting with year 2020. If you know your TV model is fr
 | DStv                     | `3201804016109`                                     |
 | Showmax                  | `3201903018045`                                     |
 | Bloomberg                | `3201412000690`                                     |
+| ARD Mediathek            | `3201412000679`                                     |
+| ZDF Mediathek            | `3201412000679`                                     |
+| HD+                      | `3201810017070`                                     |
+| RTL+                     | `3201908018988`                                     |
+| MagentaTV                | `3201907018746`                                     |
+| Joyn                     | `3201502001386`                                     |
+
+
+
 
 ## Get installed applications
 

--- a/docs/extra/applications.md
+++ b/docs/extra/applications.md
@@ -151,9 +151,6 @@ Most of the IDs changed starting with year 2020. If you know your TV model is fr
 | MagentaTV                | `3201907018746`                                     |
 | Joyn                     | `3201502001386`                                     |
 
-
-
-
 ## Get installed applications
 
 ::: warning Samsung makes our life harder ...


### PR DESCRIPTION
Added some popular German TV app-ids out of the Issue https://github.com/tavicu/homebridge-samsung-tizen/issues/602 to the documentation.
I checked the ids for the ARD and ZDF Mediathek, which works perfect for me.

It would be great, if the ids could be added to the documentation so not everybody need to luck to find the Issue to see the ids.

By the way, thank you very much for your great Plugin!