### PR TITLE
New: Added support for Samsung vendor specific media input sources (USB-C & Display Port)

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -158,7 +158,7 @@
                                     },
                                     "input": {
                                         "type": "string",
-                                        "enum": ["digitalTv", "HDMI1", "HDMI2", "HDMI3", "HDMI4", "HDMI5", "HDMI6", "USB", "AM", "FM"]
+                                        "enum": ["digitalTv", "HDMI1", "HDMI2", "HDMI3", "HDMI4", "HDMI5", "HDMI6", "Display Port", "USB", "USB-C", "AM", "FM"]
                                     },
                                     "sleep": {
                                         "type": "integer"
@@ -254,7 +254,7 @@
                                         },
                                         {
                                             "key": "devices[].mac",
-                                            "title": "MAC Address",
+                                            "title": "Network MAC Address",
                                             "placeholder": "A0:B1:C2:D3:E4:F5"
                                         }
                                     ]
@@ -327,7 +327,7 @@
                                                             "condition": {
                                                                 "functionBody": "return model.devices[arrayIndices[0]].inputs[arrayIndices[1]].type == 'input';"
                                                             },
-                                                            "enum": ["digitalTv", "HDMI1", "HDMI2", "HDMI3", "HDMI4", "HDMI5", "HDMI6", "USB", "AM", "FM"],
+                                                            "enum": ["digitalTv", "HDMI1", "HDMI2", "HDMI3", "HDMI4", "HDMI5", "HDMI6", "Display Port", "USB", "USB-C", "AM", "FM"],
                                                             "titleMap": {
                                                                 "digitalTv": "Live TV",
                                                                 "HDMI1": "HDMI 1",
@@ -336,7 +336,9 @@
                                                                 "HDMI4": "HDMI 4",
                                                                 "HDMI5": "HDMI 5",
                                                                 "HDMI6": "HDMI 6",
+                                                                "Display Port": "Display Port",	
                                                                 "USB": "USB",
+                                                                "USB-C": "USB-C",
                                                                 "AM": "AM",
                                                                 "FM": "FM"
                                                             }
@@ -391,6 +393,8 @@
                                                             "titleMap": {
                                                                 "digitalTv": "Live TV",
                                                                 "USB": "USB",
+                                                                "USB-C": "USB-C",
+                                                                "Display Port": "Display Port",	
                                                                 "HDMI1": "HDMI 1",
                                                                 "HDMI2": "HDMI 2",
                                                                 "HDMI3": "HDMI 3",

--- a/lib/services/input.js
+++ b/lib/services/input.js
@@ -37,7 +37,7 @@ module.exports = class Input {
             return Hap.Characteristic.InputSourceType.TUNER;
         }
 
-        if (this.config.value == 'USB') {
+        if (this.config.value && this.config.value.startsWith('USB')) {
             return Hap.Characteristic.InputSourceType.USB;
         }
 

--- a/lib/smartthings.js
+++ b/lib/smartthings.js
@@ -66,7 +66,13 @@ module.exports = class SmartThings {
     }
 
     setInputSource(value) {
-        return this.sendCommands({component: 'main', capability: 'mediaInputSource', command: 'setInputSource', arguments: [value]});
+        // Try to set input source with Samsung-specific vendor extended capability (used in e.g. smart monitors)
+        return this.sendCommands({component: 'main', capability: 'samsungvd.mediaInputSource', command: 'setInputSource', arguments: [value]})
+            .catch((error) => {
+                // Catch errors (422) potentially due to unsupported capability and fallback to standard capability (used in most Samsung TVs)
+                this.device.log.debug('Failed to set input source with Samsung-specific vendor extended capability, falling back to standard capability.', error);
+                return this.sendCommands({component: 'main', capability: 'mediaInputSource', command: 'setInputSource', arguments: [value]});
+            });
     }
 
     setPictureMode(value) {


### PR DESCRIPTION
## Description
I've added the highly requested feature of supporting Samsung vendor specific inputs, like the ones available on their OLED smart monitor lineup - `USB-C` and `Display Port` (https://github.com/tavicu/homebridge-samsung-tizen/issues/644, https://github.com/tavicu/homebridge-samsung-tizen/issues/632, https://github.com/tavicu/homebridge-samsung-tizen/issues/569). The two new inputs are now available under the input dropdown, as well as under the switch dropdown. The request for switching the new inputs utilizes the `samsungvd.mediaInputSource`, which also supports the traditional inputs. Should the request fail, it gracefully falls back to the original capability of `mediaInputSource` used in traditional TVs and leaves a debug level message in the console.

Furthermore, I've renamed the field `MAC Address` to `Network MAC Address`, so that it's clear, that the Network (Ethernet/WLAN/Wi-Fi) address is the one relevant. Not to confuse it with the Bluetooth address for example.

I've tested the added feature on my Samsung OLED G8 and I can confirm the input switching works quite well.  

## Contribution
I'd be honored to be added to the credits section for this contribution!  Of course, no worries at all if you prefer not to. Regardless, I'm happy to have been able to help out. Cheers! 😉

## Screenshots

### Inputs Dropdown
![image](https://github.com/tavicu/homebridge-samsung-tizen/assets/73225488/1701092d-9b5b-4667-924d-c5dd774554bb)

### Switch Dropdown
![image](https://github.com/tavicu/homebridge-samsung-tizen/assets/73225488/412082ec-6e2a-4853-b32f-6b4952a3bb90)

### HomeKit
- DESKTOP utilizes `Display Port`
- MacBook Air utilizes `USB-C`
- HDMI is self explanatory 

![Screenshot 2024-04-25 at 22 04 42](https://github.com/tavicu/homebridge-samsung-tizen/assets/73225488/296ac74f-485f-4efa-a6ad-bd917205701d)  

### Network MAC Address
![image](https://github.com/tavicu/homebridge-samsung-tizen/assets/73225488/6a832582-3bce-4641-9a8d-9eebc7d93b6a)

- resolves #644 
- resolves #632 
- resolves #569
