### PR TITLE
Update: Added option to use SmartThings to fetch device power state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 ehthumbs.db
 Thumbs.db
 Icon
+.vscode
 
 node_modules
 dist

--- a/config.schema.json
+++ b/config.schema.json
@@ -484,7 +484,7 @@
                                                 "wss": "Default",
                                                 "frame": "Frame"
                                             },
-                                            "description": "The plugin detects the type of TV <b>automaticaly</b>. Leave this option set to <b>None</b> unless you are having problems and the plugin don't detect your TV type correctly."
+                                            "description": "The plugin detects the type of TV <b>automatically</b>. Leave this option set to <b>None</b> unless you are having problems and the plugin don't detect your TV type correctly."
                                         },
                                         {
                                             "key": "devices[].uuid",
@@ -496,7 +496,7 @@
                                             "key": "devices[].delay",
                                             "title": "Command Delay Interval",
                                             "placeholder": "400",
-                                            "description": "This is the delay between each command when you send multiple commands. By lowering the value you risk the commands not being executed. Value is in <b>miliseconds</b>."
+                                            "description": "This is the delay between each command when you send multiple commands. By lowering the value you risk the commands not being executed. Value is in <b>milliseconds</b>."
                                         },
                                         {
                                             "key": "devices[].options",

--- a/config.schema.json
+++ b/config.schema.json
@@ -158,7 +158,7 @@
                                     },
                                     "input": {
                                         "type": "string",
-                                        "enum": ["digitalTv", "HDMI1", "HDMI2", "HDMI3", "HDMI4", "HDMI5", "HDMI6", "Display Port", "USB", "USB-C", "AM", "FM"]
+                                        "enum": ["digitalTv", "HDMI1", "HDMI2", "HDMI3", "HDMI4", "HDMI5", "HDMI6", "USB", "AM", "FM"]
                                     },
                                     "sleep": {
                                         "type": "integer"
@@ -254,7 +254,7 @@
                                         },
                                         {
                                             "key": "devices[].mac",
-                                            "title": "Network MAC Address",
+                                            "title": "MAC Address",
                                             "placeholder": "A0:B1:C2:D3:E4:F5"
                                         }
                                     ]
@@ -334,7 +334,7 @@
                                                             "condition": {
                                                                 "functionBody": "return model.devices[arrayIndices[0]].inputs[arrayIndices[1]].type == 'input';"
                                                             },
-                                                            "enum": ["digitalTv", "HDMI1", "HDMI2", "HDMI3", "HDMI4", "HDMI5", "HDMI6", "Display Port", "USB", "USB-C", "AM", "FM"],
+                                                            "enum": ["digitalTv", "HDMI1", "HDMI2", "HDMI3", "HDMI4", "HDMI5", "HDMI6", "USB", "AM", "FM"],
                                                             "titleMap": {
                                                                 "digitalTv": "Live TV",
                                                                 "HDMI1": "HDMI 1",
@@ -343,9 +343,7 @@
                                                                 "HDMI4": "HDMI 4",
                                                                 "HDMI5": "HDMI 5",
                                                                 "HDMI6": "HDMI 6",
-                                                                "Display Port": "Display Port",	
                                                                 "USB": "USB",
-                                                                "USB-C": "USB-C",
                                                                 "AM": "AM",
                                                                 "FM": "FM"
                                                             }
@@ -400,8 +398,6 @@
                                                             "titleMap": {
                                                                 "digitalTv": "Live TV",
                                                                 "USB": "USB",
-                                                                "USB-C": "USB-C",
-                                                                "Display Port": "Display Port",	
                                                                 "HDMI1": "HDMI 1",
                                                                 "HDMI2": "HDMI 2",
                                                                 "HDMI3": "HDMI 3",

--- a/config.schema.json
+++ b/config.schema.json
@@ -507,7 +507,7 @@
                                             "title": "Options",
                                             "titleMap": {
                                                 "Switch.DeviceName.Disable": "Disable prepending the device name on custom switches",
-                                                "Frame.RealPowerMode": "Display and control Real Power with Main Acccessory (for Frame TVs)",
+                                                "Frame.RealPowerMode": "Display and control Real Power with Main Accessory (for Frame TVs)",
                                                 "Frame.ArtSwitch.Disable": "Disable Art Switch (for Frame TVs)",
                                                 "Frame.PowerSwitch.Disable": "Disable Power Switch (for Frame TVs)"
                                             }

--- a/config.schema.json
+++ b/config.schema.json
@@ -82,7 +82,7 @@
                         "wait_time": {"type": "integer"},
                         "api_key": {"type": "string"},
                         "device_id": {"type": "string"},
-
+                        "use_smartthings_for_power_state": {"type": "boolean"},
                         "name": {
                             "type": "string",
                             "required": true
@@ -240,8 +240,8 @@
                                     "default": "Bedroom TV"
                                 },
                                 {
-                                  "type": "help",
-                                  "helpvalue": "<p class='help-block'>Make sure that your device have a static IP address. You can set it from your router admin interface!</p>"
+                                    "type": "help",
+                                    "helpvalue": "<p class='help-block'>Make sure that your device has a static IP address. You can set it from your router admin interface!</p>"
                                 },
                                 {
                                     "type": "flex",
@@ -264,8 +264,8 @@
                                     "title": "SmartThings API",
                                     "items": [
                                         {
-                                          "type": "help",
-                                          "helpvalue": "<p class='help-block'>SmartThings API is <strong>optional</strong>. You will need to set these parameters only if you want to use inputs! Please <a href='https://tavicu.github.io/homebridge-samsung-tizen/configuration/smartthings-api.html' target='_blank'>follow this tutorial</a>.</p>"
+                                            "type": "help",
+                                            "helpvalue": "<p class='help-block'>SmartThings API is <strong>optional</strong> but highly recommended for more reliable power state (see <i>\"Use SmartThings for Power State\"</i>) detection and input management. If provided, it will be used for enhanced functionality such as fetching the power state more effectively and managing inputs. Please <a href='https://tavicu.github.io/homebridge-samsung-tizen/configuration/smartthings-api.html' target='_blank'>follow this tutorial</a> to set it up.</p>"
                                         },
                                         {
                                             "key": "devices[].api_key",
@@ -274,7 +274,14 @@
                                         {
                                             "key": "devices[].device_id",
                                             "title": "Device ID"
-                                        }
+                                        },
+                                        {
+                                            "key": "devices[].use_smartthings_for_power_state",
+                                            "type": "boolean",
+                                            "default": false,
+                                            "title": "Use SmartThings for Power State",
+                                            "description": "Enable to use the SmartThings API to check the power state of the TV. This can provide more accurate results. Ensure you have provided a valid API Key and Device ID."
+                                        }                                        
                                     ]
                                 },
                                 {
@@ -285,7 +292,7 @@
                                     "items": [
                                         {
                                             "type": "help",
-                                            "helpvalue": "<p class='help-block'>By default no inputs are set. Use this section to set your own inputs. You can find more informations on our <a href='https://tavicu.github.io/homebridge-samsung-tizen/features/inputs.html' target='_blank'>documentation</a>.</p>"
+                                            "helpvalue": "<p class='help-block'>By default, no inputs are set. Use this section to configure your own inputs. For more information, please refer to our <a href='https://tavicu.github.io/homebridge-samsung-tizen/features/inputs.html' target='_blank'>documentation</a>.</p>"
                                         },
                                         {
                                             "type": "array",
@@ -357,7 +364,7 @@
                                     "items": [
                                         {
                                             "type": "help",
-                                            "helpvalue": "<p class='help-block'>This section give you the option to create custom switches (separated accessories) that make specific actions. You can find more informations on our <a href='https://tavicu.github.io/homebridge-samsung-tizen/features/switches.html' target='_blank'>documentation</a>.</p>"
+                                            "helpvalue": "<p class='help-block'>This section allows you to create custom switches (separate accessories) that perform specific actions. For more information, please visit our <a href='https://tavicu.github.io/homebridge-samsung-tizen/features/switches.html' target='_blank'>documentation</a>.</p>"
                                         },
                                         {
                                             "type": "array",
@@ -499,7 +506,7 @@
                                             "key": "devices[].options",
                                             "title": "Options",
                                             "titleMap": {
-                                                "Switch.DeviceName.Disable": "Disable prepending device name on custom switches",
+                                                "Switch.DeviceName.Disable": "Disable prepending the device name on custom switches",
                                                 "Frame.RealPowerMode": "Display and control Real Power with Main Acccessory (for Frame TVs)",
                                                 "Frame.ArtSwitch.Disable": "Disable Art Switch (for Frame TVs)",
                                                 "Frame.PowerSwitch.Disable": "Disable Power Switch (for Frame TVs)"
@@ -515,7 +522,7 @@
                                             "items": [
                                                 {
                                                     "type": "help",
-                                                    "helpvalue": "<p class='help-block'>You don't have to edit this section unless you want to change the default commands for <b>Remote Control</b> buttons. You can find more informations on our <a href='https://tavicu.github.io/homebridge-samsung-tizen/features/keys.html' target='_blank'>documentation</a>.</p>",
+                                                    "helpvalue": "<p class='help-block'>You do not need to edit this section unless you want to change the default commands for <b>Remote Control</b> buttons. For more information, please refer to our <a href='https://tavicu.github.io/homebridge-samsung-tizen/features/keys.html' target='_blank'>documentation</a>.</p>",
                                                     "flex": "1 1 100%"
                                                 },
                                                 {

--- a/config.schema.json
+++ b/config.schema.json
@@ -158,7 +158,7 @@
                                     },
                                     "input": {
                                         "type": "string",
-                                        "enum": ["digitalTv", "HDMI1", "HDMI2", "HDMI3", "HDMI4", "HDMI5", "HDMI6", "USB", "AM", "FM"]
+                                        "enum": ["digitalTv", "HDMI1", "HDMI2", "HDMI3", "HDMI4", "HDMI5", "HDMI6", "Display Port", "USB", "USB-C", "AM", "FM"]
                                     },
                                     "sleep": {
                                         "type": "integer"
@@ -254,7 +254,7 @@
                                         },
                                         {
                                             "key": "devices[].mac",
-                                            "title": "MAC Address",
+                                            "title": "Network MAC Address",
                                             "placeholder": "A0:B1:C2:D3:E4:F5"
                                         }
                                     ]
@@ -327,7 +327,7 @@
                                                             "condition": {
                                                                 "functionBody": "return model.devices[arrayIndices[0]].inputs[arrayIndices[1]].type == 'input';"
                                                             },
-                                                            "enum": ["digitalTv", "HDMI1", "HDMI2", "HDMI3", "HDMI4", "HDMI5", "HDMI6", "USB", "AM", "FM"],
+                                                            "enum": ["digitalTv", "HDMI1", "HDMI2", "HDMI3", "HDMI4", "HDMI5", "HDMI6", "Display Port", "USB", "USB-C", "AM", "FM"],
                                                             "titleMap": {
                                                                 "digitalTv": "Live TV",
                                                                 "HDMI1": "HDMI 1",
@@ -336,7 +336,9 @@
                                                                 "HDMI4": "HDMI 4",
                                                                 "HDMI5": "HDMI 5",
                                                                 "HDMI6": "HDMI 6",
+                                                                "Display Port": "Display Port",	
                                                                 "USB": "USB",
+                                                                "USB-C": "USB-C",
                                                                 "AM": "AM",
                                                                 "FM": "FM"
                                                             }
@@ -391,6 +393,8 @@
                                                             "titleMap": {
                                                                 "digitalTv": "Live TV",
                                                                 "USB": "USB",
+                                                                "USB-C": "USB-C",
+                                                                "Display Port": "Display Port",	
                                                                 "HDMI1": "HDMI 1",
                                                                 "HDMI2": "HDMI 2",
                                                                 "HDMI3": "HDMI 3",

--- a/config.schema.json
+++ b/config.schema.json
@@ -82,7 +82,7 @@
                         "wait_time": {"type": "integer"},
                         "api_key": {"type": "string"},
                         "device_id": {"type": "string"},
-                        "use_smartthings_for_power_state": {"type": "boolean"},
+                        "use_smartthings_power": {"type": "boolean"},
                         "name": {
                             "type": "string",
                             "required": true
@@ -276,11 +276,11 @@
                                             "title": "Device ID"
                                         },
                                         {
-                                            "key": "devices[].use_smartthings_for_power_state",
+                                            "key": "devices[].use_smartthings_power",
                                             "type": "boolean",
                                             "default": false,
                                             "title": "Use SmartThings for Power State",
-                                            "description": "Enable to use the SmartThings API to check the power state of the TV. This can provide more accurate results. Ensure you have provided a valid API Key and Device ID."
+                                            "description": "Enable to use the SmartThings API to check the power state of the TV. This could provide more accurate power readings. Ensure you have provided a valid API Key and Device ID."
                                         }                                        
                                     ]
                                 },

--- a/lib/device.js
+++ b/lib/device.js
@@ -23,7 +23,8 @@ module.exports = class Device extends EventEmitter {
                 wol       : {},
                 options   : [],
                 api_key   : null,
-                device_id : null
+                device_id : null,
+                use_smartthings_for_power_state : false
             },
             Platform.config,
             config

--- a/lib/device.js
+++ b/lib/device.js
@@ -24,7 +24,7 @@ module.exports = class Device extends EventEmitter {
                 options   : [],
                 api_key   : null,
                 device_id : null,
-                use_smartthings_for_power_state : false
+                use_smartthings_power : false
             },
             Platform.config,
             config

--- a/lib/methods/base.js
+++ b/lib/methods/base.js
@@ -67,7 +67,7 @@ module.exports = class Base {
     }
 
     /**
-     * Fetches the TV's power state via HTTP if ping succeeds.
+     * Fetches the TV's power state via the local TV's API.
      * @param  {boolean} fallback - Fallback value if HTTP request fails.
      * @return {Promise<boolean>}
      */

--- a/lib/methods/base.js
+++ b/lib/methods/base.js
@@ -42,7 +42,9 @@ module.exports = class Base {
      */
     getState() {
         return this.cache.get('state', () => this.getStatePing().then(status => {
+            this.device.log.debug(`Ping status: ${status}`);
             if (status && this.device.storage.powerstate !== false) {
+                this.device.log.debug('Ping succeeded, fetching power state via HTTP...');
                 return this.cache.get('state-http', () => this.getStateHttp(status), 2500);
             } else {
                 this.cache.forget('state-http');
@@ -57,6 +59,7 @@ module.exports = class Base {
      * @return {Promise<boolean>}
      */
     getStatePing() {
+        this.device.log.debug(`Pinging ${this.ip} with timeout ${this.timeout}ms.`);
         return isPortReachable(8001, {
             host: this.ip,
             timeout: this.timeout
@@ -69,8 +72,10 @@ module.exports = class Base {
      * @return {Promise<boolean>}
      */
     getStateHttp(fallback = false) {
+        this.device.log.debug(`Fetching power state from ${this.ip} local TV API.`);
         return this.getInfo().then(data => {
             if (data.device && data.device.PowerState) {
+                this.device.log.debug(`Power state: ${data.device.PowerState}`);
                 return data.device.PowerState == 'on';
             }
 

--- a/lib/methods/base.js
+++ b/lib/methods/base.js
@@ -67,7 +67,7 @@ module.exports = class Base {
     }
 
     /**
-     * Fetches the TV's power state via the local TV's API.
+     * Fetches the TV's power state via its local API.
      * @param  {boolean} fallback - Fallback value if HTTP request fails.
      * @return {Promise<boolean>}
      */

--- a/lib/methods/base.js
+++ b/lib/methods/base.js
@@ -19,17 +19,26 @@ module.exports = class Base {
         this.cache   = device.cache;
     }
 
+    /**
+     * Cleans up resources or state.
+     */
     destroy() {
         this.destroyed = true;
     }
 
+    /**
+     * Simulates a pairing delay.
+     * @return {Promise<void>}
+     */
     pair() {
         return utils.delay(500);
     }
 
     /**
-     * Get state of TV with cache
-     * @return {Cache}
+     * Retrieves the TV's power state by first attempting a network ping.
+     * If the ping succeeds, it validates the power state via HTTP.
+     * If the ping fails, it assumes the TV is off, unless previously recorded as on.
+     * @return {Promise<boolean>} Resolves with true if on, false if off.
      */
     getState() {
         return this.cache.get('state', () => this.getStatePing().then(status => {
@@ -44,8 +53,8 @@ module.exports = class Base {
     }
 
     /**
-     * Get state of TV by sending a Ping
-     * @return {Promise}
+     * Checks TV availability via network ping.
+     * @return {Promise<boolean>}
      */
     getStatePing() {
         return isPortReachable(8001, {
@@ -55,9 +64,9 @@ module.exports = class Base {
     }
 
     /**
-     * Get state of TV from PowerState response
-     * @param  {boolean} fallback
-     * @return {Promise}
+     * Fetches the TV's power state via HTTP if ping succeeds.
+     * @param  {boolean} fallback - Fallback value if HTTP request fails.
+     * @return {Promise<boolean>}
      */
     getStateHttp(fallback = false) {
         return this.getInfo().then(data => {
@@ -71,8 +80,8 @@ module.exports = class Base {
     }
 
     /**
-     * Turn the TV On
-     * @return {Promise}
+     * Powers on the TV. Uses Wake-on-LAN if necessary.
+     * @return {Promise<void>}
      */
     async setStateOn() {
         // If TV is in Sleep mode just send command
@@ -90,16 +99,16 @@ module.exports = class Base {
     }
 
     /**
-     * Turn the TV Off
-     * @return {Promise}
+     * Powers off the TV.
+     * @return {Promise<void>}
      */
     setStateOff() {
         return this.click('KEY_POWER');
     }
 
     /**
-     * Get TV informations
-     * @return {Promise}
+     * Retrieves device information from the TV's API.
+     * @return {Promise<Object>}
      */
     getInfo() {
         return fetch(`http://${this.ip}:8001/api/v2/`, {
@@ -110,9 +119,9 @@ module.exports = class Base {
     }
 
     /**
-     * Get Application Informations
-     * @param  {Number} appId
-     * @return {Promise}
+     * Retrieves information about a specific application.
+     * @param  {number} appId - The application ID.
+     * @return {Promise<Object>}
      */
     getApplication(appId) {
         return fetch(`http://${this.ip}:8001/api/v2/applications/${appId}`, {
@@ -122,9 +131,9 @@ module.exports = class Base {
     }
 
     /**
-     * Launch Application
-     * @param  {Number} appId
-     * @return {Promise}
+     * Launches an application on the TV.
+     * @param  {number} appId - The application ID to launch.
+     * @return {Promise<void>}
      */
     startApplication(appId) {
         return fetch(`http://${this.ip}:8001/api/v2/applications/${appId}`, {
@@ -135,8 +144,8 @@ module.exports = class Base {
     }
 
     /**
-     * Encode TV name to base64
-     * @return {string}
+     * Encodes the TV name to base64.
+     * @return {string} The encoded TV name.
      */
     _encodeName() {
         return new Buffer.from(this.name).toString('base64');

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -119,6 +119,13 @@ module.exports = class Remote {
         if (this.turningOff  !== null) { return false; }
         if (this.standbyMode !== null) { return false; }
 
+        // If SmartThings API is available, use it to get the power state reliably, otherwise fall back to default API method
+        if (this.smartthings.available && this.device.config.use_smartthings_for_power_state) {
+            const powerState = await this.smartthings.getSwitchState();
+            if (powerState !== null) { return powerState; }
+            this.device.log.debug("SmartThings API call failed, falling back to default API method.");
+        }
+
         return await this.api.getState();
     }
 

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -121,7 +121,7 @@ module.exports = class Remote {
 
         // If SmartThings API is available, use it to get the power state reliably, otherwise fall back to default API method
         if (this.smartthings.available && this.device.config.use_smartthings_power) {
-            return this.cache.get('smartthings-power-state', () => this.smartthings.getSwitchState(), 2500)
+            return this.cache.get('smartthings-power-state', () => this.smartthings.getPowerState(), 2500)
                 .then(powerState => {
                     if (powerState !== null) { return powerState; }
                     this.device.log.debug("SmartThings API call failed, falling back to default API method.");

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -63,7 +63,7 @@ module.exports = class Remote {
 
         let method = MethodWSS;
 
-        switch(this.device.config.method) {
+        switch (this.device.config.method) {
             case 'ws':
                 method = MethodWS;
                 break;
@@ -339,7 +339,7 @@ module.exports = class Remote {
 
             if (split[1]) {
                 if (/^.*\*[0-9]*[.]?[0-9]+s$/.test(cmd)) {
-                    return {key: split[0], time: parseFloat(split[1])};
+                    return { key: split[0], time: parseFloat(split[1]) };
                 }
 
                 return Array(parseInt(split[1])).fill(split[0]);

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -120,7 +120,7 @@ module.exports = class Remote {
         if (this.standbyMode !== null) { return false; }
 
         // If SmartThings API is available, use it to get the power state reliably, otherwise fall back to default API method
-        if (this.smartthings.available && this.device.config.use_smartthings_for_power_state) {
+        if (this.smartthings.available && this.device.config.use_smartthings_power) {
             return this.cache.get('smartthings-power-state', () => this.smartthings.getSwitchState(), 2500)
                 .then(powerState => {
                     if (powerState !== null) { return powerState; }

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -121,11 +121,14 @@ module.exports = class Remote {
 
         // If SmartThings API is available, use it to get the power state reliably, otherwise fall back to default API method
         if (this.smartthings.available && this.device.config.use_smartthings_for_power_state) {
-            const powerState = await this.smartthings.getSwitchState();
-            if (powerState !== null) { return powerState; }
-            this.device.log.debug("SmartThings API call failed, falling back to default API method.");
+            return this.cache.get('smartthings-power-state', () => this.smartthings.getSwitchState(), 2500)
+                .then(powerState => {
+                    if (powerState !== null) { return powerState; }
+                    this.device.log.debug("SmartThings API call failed, falling back to default API method.");
+                    return this.api.getState();
+                });
         }
-
+    
         return await this.api.getState();
     }
 

--- a/lib/services/input.js
+++ b/lib/services/input.js
@@ -37,7 +37,7 @@ module.exports = class Input {
             return Hap.Characteristic.InputSourceType.TUNER;
         }
 
-        if (this.config.value && this.config.value.startsWith('USB')) {
+        if (this.config.value == 'USB') {
             return Hap.Characteristic.InputSourceType.USB;
         }
 

--- a/lib/services/input.js
+++ b/lib/services/input.js
@@ -37,7 +37,7 @@ module.exports = class Input {
             return Hap.Characteristic.InputSourceType.TUNER;
         }
 
-        if (this.config.value == 'USB') {
+        if (this.config.value && this.config.value.startsWith('USB')) {
             return Hap.Characteristic.InputSourceType.USB;
         }
 

--- a/lib/smartthings.js
+++ b/lib/smartthings.js
@@ -71,11 +71,11 @@ module.exports = class SmartThings {
     }
 
     /**
-     * Fetches the current state of the switch capability from the SmartThings API.
-     * Returns a boolean if successful, or null if an error occurs.
+     * Fetches the current powers state of the device (switch capability) from the SmartThings API.
+     * Returns a boolean, representing the device's power state, if successful, or null if an error occurs.
      * @returns {Promise<boolean|null>}
      */
-    getSwitchState() {
+    getPowerState() {
         return this._send(this.api_switch)
             .then(response => {
                 // Check the response for the switch state

--- a/lib/smartthings.js
+++ b/lib/smartthings.js
@@ -22,6 +22,7 @@ module.exports = class SmartThings {
         this.api_device  = this.api_devices + this.device_id;
         this.api_status  = this.api_device + '/states';
         this.api_command = this.api_device + '/commands';
+        this.api_switch  = this.api_device + '/components/main/capabilities/switch/status';
         this.api_headers = { 'Authorization': 'Bearer ' + this.api_key };
 
         // Emit init event
@@ -36,12 +37,12 @@ module.exports = class SmartThings {
         return this.device.cache.get(`st-status`, () => this.refresh()
             .then(() => this._send(this.api_status))
             .catch(() => ({})
-        ), 2500).then(response => ({
-            pictureMode: response.main.pictureMode,
-            tvChannel: response.main.tvChannel,
-            tvChannelName: response.main.tvChannelName,
-            inputSource: response.main.inputSource
-        }));
+            ), 2500).then(response => ({
+                pictureMode: response.main.pictureMode,
+                tvChannel: response.main.tvChannel,
+                tvChannelName: response.main.tvChannelName,
+                inputSource: response.main.inputSource
+            }));
     }
 
     getPictureMode() {
@@ -67,6 +68,30 @@ module.exports = class SmartThings {
 
             return response.inputSource;
         });
+    }
+
+    /**
+     * Fetches the current state of the switch capability from the SmartThings API.
+     * Returns a boolean if successful, or null if an error occurs.
+     * @returns {Promise<boolean|null>}
+     */
+    getSwitchState() {
+        return this._send(this.api_switch)
+            .then(response => {
+                // Check the response for the switch state
+                if (response && response.switch && typeof response.switch.value === 'string') {
+                    this.device.log.debug(`Switch state fetched: ${response.switch.value}`);
+                    // Return true if 'on', otherwise false
+                    return response.switch.value === 'on';
+                }
+                // If response structure is not as expected, log and return null
+                throw new SmartThingsResponse('Unexpected response structure when fetching switch (power) state');
+            })
+            .catch(error => {
+                // Log any errors and return null
+                this.device.log.debug(`Error fetching switch state: ${error}`);
+                return new Promise(null);
+            });
     }
 
     /**
@@ -136,7 +161,7 @@ module.exports = class SmartThings {
         return this._send(this.api_command, {
             commands: commands
         }, 'post');
-        }
+    }
 
     /**
      * Sends a request to the specified endpoint with the provided data using the specified HTTP method.
@@ -157,25 +182,25 @@ module.exports = class SmartThings {
                 body: JSON.stringify(data),
                 headers: this.api_headers
             })
-            .then(response => {
-                const contentType = response.headers.get('content-type');
+                .then(response => {
+                    const contentType = response.headers.get('content-type');
 
-                if (!contentType || !contentType.includes('application/json')) {
-                    throw new SmartThingsResponse(`${response.status} - ${response.statusText}`);
-                }
+                    if (!contentType || !contentType.includes('application/json')) {
+                        throw new SmartThingsResponse(`${response.status} - ${response.statusText}`);
+                    }
 
-                return response.json();
-             })
-             .then(response => {
-                this.device.log.debug(JSON.stringify(response));
+                    return response.json();
+                })
+                .then(response => {
+                    this.device.log.debug(JSON.stringify(response));
 
-                if (response.error) {
-                    reject(response.error);
-                }
+                    if (response.error) {
+                        reject(response.error);
+                    }
 
-                resolve(response);
-            })
-            .catch(error => reject(error));
+                    resolve(response);
+                })
+                .catch(error => reject(error));
         });
     }
 

--- a/lib/smartthings.js
+++ b/lib/smartthings.js
@@ -93,7 +93,7 @@ module.exports = class SmartThings {
                 return new Promise(null);
             });
     }
-
+    
     /**
      * Refreshes the main component's capability.
      * @returns {Promise} A promise that resolves when the refresh command is sent.
@@ -109,13 +109,7 @@ module.exports = class SmartThings {
      * @returns {Promise} A promise that resolves when the input source is set successfully.
      */
     setInputSource(value) {
-        // Try to set input source with Samsung-specific vendor extended capability (used in e.g. smart monitors)
-        return this.sendCommands({ component: 'main', capability: 'samsungvd.mediaInputSource', command: 'setInputSource', arguments: [value] })
-            .catch((error) => {
-                // Catch errors (422) potentially due to unsupported capability and fallback to standard capability (used in most Samsung TVs)
-                this.device.log.debug('Failed to set input source with Samsung-specific vendor extended capability, falling back to standard capability.', error);
-                return this.sendCommands({ component: 'main', capability: 'mediaInputSource', command: 'setInputSource', arguments: [value] });
-            });
+        return this.sendCommands({component: 'main', capability: 'mediaInputSource', command: 'setInputSource', arguments: [value]});
     }
 
     /**

--- a/lib/smartthings.js
+++ b/lib/smartthings.js
@@ -22,12 +22,16 @@ module.exports = class SmartThings {
         this.api_device  = this.api_devices + this.device_id;
         this.api_status  = this.api_device + '/states';
         this.api_command = this.api_device + '/commands';
-        this.api_headers = {'Authorization': 'Bearer ' + this.api_key};
+        this.api_headers = { 'Authorization': 'Bearer ' + this.api_key };
 
         // Emit init event
         setTimeout(() => this.device.emit('smartthings.init'));
     }
 
+    /**
+     * Retrieves the status of the device.
+     * @returns {Promise<Object>} A promise that resolves to an object containing the device status.
+     */
     getStatus() {
         return this.device.cache.get(`st-status`, () => this.refresh()
             .then(() => this._send(this.api_status))
@@ -44,6 +48,10 @@ module.exports = class SmartThings {
         return this.getStatus().then(response => response.pictureMode);
     }
 
+    /**
+     * Retrieves the current input source of the TV.
+     * @returns {Promise<string>} A promise that resolves with the input source of the TV.
+     */
     getInputSource() {
         return this.getStatus().then(response => {
             // Some TVs report inputSource as dtv, transform it to digitalTv
@@ -61,32 +69,65 @@ module.exports = class SmartThings {
         });
     }
 
+    /**
+     * Refreshes the main component's capability.
+     * @returns {Promise} A promise that resolves when the refresh command is sent.
+     */
     refresh() {
-        return this.sendCommands({component: 'main', capability: 'refresh', command: 'refresh'});
+        return this.sendCommands({ component: 'main', capability: 'refresh', command: 'refresh' });
     }
 
+    /**
+     * Sets the input source for the device.
+     *
+     * @param {string} value - The input source value to set.
+     * @returns {Promise} A promise that resolves when the input source is set successfully.
+     */
     setInputSource(value) {
         // Try to set input source with Samsung-specific vendor extended capability (used in e.g. smart monitors)
-        return this.sendCommands({component: 'main', capability: 'samsungvd.mediaInputSource', command: 'setInputSource', arguments: [value]})
+        return this.sendCommands({ component: 'main', capability: 'samsungvd.mediaInputSource', command: 'setInputSource', arguments: [value] })
             .catch((error) => {
                 // Catch errors (422) potentially due to unsupported capability and fallback to standard capability (used in most Samsung TVs)
                 this.device.log.debug('Failed to set input source with Samsung-specific vendor extended capability, falling back to standard capability.', error);
-                return this.sendCommands({component: 'main', capability: 'mediaInputSource', command: 'setInputSource', arguments: [value]});
+                return this.sendCommands({ component: 'main', capability: 'mediaInputSource', command: 'setInputSource', arguments: [value] });
             });
     }
 
+    /**
+     * Sets the picture mode of the device.
+     *
+     * @param {string} value - The value representing the picture mode.
+     * @returns {Promise} A promise that resolves when the command is sent successfully.
+     */
     setPictureMode(value) {
-        return this.sendCommands({component: 'main', capability: 'custom.picturemode', command: 'setPictureMode', arguments: [value]});
+        return this.sendCommands({ component: 'main', capability: 'custom.picturemode', command: 'setPictureMode', arguments: [value] });
     }
 
+    /**
+     * Sets the TV channel.
+     *
+     * @param {string} value - The channel value to set.
+     * @returns {Promise} A promise that resolves when the command is sent.
+     */
     setTvChannel(value) {
-        return this.sendCommands({component: 'main', capability: 'tvChannel', command: 'setTvChannel', arguments: [value + '']});
+        return this.sendCommands({ component: 'main', capability: 'tvChannel', command: 'setTvChannel', arguments: [value + ''] });
     }
 
+    /**
+     * Sets the volume of the audio.
+     *
+     * @param {number} value - The volume value to set.
+     * @returns {Promise} A promise that resolves when the volume is set.
+     */
     setVolume(value) {
-        return this.sendCommands({component: 'main', capability: 'audioVolume', command: 'setVolume', arguments: [parseInt(value)]});
+        return this.sendCommands({ component: 'main', capability: 'audioVolume', command: 'setVolume', arguments: [parseInt(value)] });
     }
 
+    /**
+     * Sends commands to the SmartThings API.
+     * @param {Array|Object} commands - The commands to send. Can be an array of commands or a single command object.
+     * @returns {Promise} A promise that resolves with the response from the API.
+     */
     sendCommands(commands) {
         if (!Array.isArray(commands)) {
             commands = [commands];
@@ -95,8 +136,15 @@ module.exports = class SmartThings {
         return this._send(this.api_command, {
             commands: commands
         }, 'post');
-    }
+        }
 
+    /**
+     * Sends a request to the specified endpoint with the provided data using the specified HTTP method.
+     * @param {string} endpoint - The URL endpoint to send the request to.
+     * @param {object} data - The data to send in the request body (optional).
+     * @param {string} method - The HTTP method to use for the request (optional, defaults to 'get').
+     * @returns {Promise<object>} - A promise that resolves with the response data or rejects with an error.
+     */
     _send(endpoint, data, method) {
         this._validate();
 
@@ -131,6 +179,10 @@ module.exports = class SmartThings {
         });
     }
 
+    /**
+     * Validates the API key and device ID are set.
+     * @throws {SmartThingsNotSet} If the API key or device ID is not set.
+     */
     _validate() {
         if (this.api_key && this.device_id) return;
 

--- a/lib/smartthings.js
+++ b/lib/smartthings.js
@@ -66,7 +66,13 @@ module.exports = class SmartThings {
     }
 
     setInputSource(value) {
-        return this.sendCommands({component: 'main', capability: 'mediaInputSource', command: 'setInputSource', arguments: [value]});
+        // Try to set input source with Samsung-specific vendor extended capability (used in e.g. smart monitors)
+        return this.sendCommands({component: 'main', capability: 'samsungvd.mediaInputSource', command: 'setInputSource', arguments: [value]})
+            .catch((error) => {
+                // Catch errors (422) potentially due to unsupported capability and fallback to standard capability (used in most Samsung TVs)
+                this.device.log.debug('Failed to set input source with Samsung-specific vendor extended capability, falling back to standard capability.', error);
+                return this.sendCommands({component: 'main', capability: 'mediaInputSource', command: 'setInputSource', arguments: [value]});
+            });
     }
 
     setPictureMode(value) {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "homebridge-samsung-tizen",
   "displayName": "Homebridge Samsung Tizen",
-  "version": "5.4.0-alpha.2",
-  "description": "Homebridge plugin for Samsung TV's with Tizen OS",
+  "version": "5.2.7",
+  "description": "Homebridge plugin for Samsung TVs with Tizen OS",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-samsung-tizen",
   "displayName": "Homebridge Samsung Tizen",
-  "version": "5.2.7",
+  "version": "5.4.0-alpha.1",
   "description": "Homebridge plugin for Samsung TV's with Tizen OS",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-samsung-tizen",
   "displayName": "Homebridge Samsung Tizen",
-  "version": "5.4.0-alpha.1",
+  "version": "5.4.0-alpha.2",
   "description": "Homebridge plugin for Samsung TV's with Tizen OS",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## Description
I've tried to implement a little something that hopefully increases the reliability of the power state reading, as I personally too experienced the random "on" states in HomeKit, although the device was actually off (see #676, #663, #608, ). What I did is I've added power state reading over the SmartThings API.

## Power State over SmartThings API
A code block for reading the state of the device over the SmartThings API was added. The code integrates with the existing logic inside the `getPower()` method of the `remote.js`. Should an error happen it is gracefully caught and the default pinging and HTTP local API flow is executed. I've tried to make it as less as invasive as possible and went against adding it inside `base.js`, as to avoid possible circular references. Also, the smart things logic is kept separate from the other ones, so the `remotes.js` felt like the best fit. 

Under the **SmartThings API** section I've added the opt-in feature to use SmartThings API for power state readings to turn it on.  
![image](https://github.com/tavicu/homebridge-samsung-tizen/assets/73225488/84f1315b-7f9d-4340-a53b-08b5f9e0a8a7)

Furthermore, an API call is sent out once every 5 seconds. This seems to be quite fine for the endpoint's rate limiter (350 requests per minute allowed). The endpoint for the GET request is under `https://api.smartthings.com/v1/devices/:deviceId/components/main/capabilities/switch/status`. This information is also found under the general status endpoint (`https://api.smartthings.com/v1/devices/:deviceId/status`), but I've narrowed it down a bit. The response looks like so: 
```json
{
  "switch": {
    "value": "on", // either "on" or "off"
    "timestamp": "2024-04-27T20:43:46.563Z"
  }
}
```

## Quality of Life Improvements
I've fixed few spelling errors and extended/improved the javascript documentation above some of the methods. Generally I tried to keep the same coding style as established in the project. Also, the additional debug logging you'll see I've added for myself to understand the inner workings better. I'd leave it up to you to decide if you'd like to keep it or not. I personally see no harm in keeping it. 

## Final thoughts
I do really like the approach you've taken first pinging the device's IP and then only if you it's reachable, you call the local device API (port `8001`). Could not really understand why the random "on" state would appear in HomeKit, although it happened to me too, but never reproduced it successfully. I hope at least this change would help resolve the issues above. 

- resolves #676 
- resolves #663
- resolves #608 