### PR TITLE
Fix ZDF Mediathek application id

### DIFF
--- a/docs/extra/applications.md
+++ b/docs/extra/applications.md
@@ -145,7 +145,7 @@ Most of the IDs changed starting with year 2020. If you know your TV model is fr
 | Showmax                  | `3201903018045`                                     |
 | Bloomberg                | `3201412000690`                                     |
 | ARD Mediathek            | `3201412000679`                                     |
-| ZDF Mediathek            | `3201412000679`                                     |
+| ZDF Mediathek            | `3201705012365`                                     |
 | HD+                      | `3201810017070`                                     |
 | RTL+                     | `3201908018988`                                     |
 | MagentaTV                | `3201907018746`                                     |


### PR DESCRIPTION
The application id of ZDF Mediathek was the same as ARD Mediathek.
I determined the correct app id via Tizen Studio.
![grafik](https://github.com/user-attachments/assets/ff1cd19b-be45-481e-90dc-6d8ac4ac46a9)
