### PR TITLE
fix: treat an empty PowerState as standby rather than unknown

### DIFF
--- a/lib/methods/base.js
+++ b/lib/methods/base.js
@@ -59,10 +59,20 @@ module.exports = class Base {
      */
     getStateHttp(fallback = false) {
         return this.getInfo().then(data => {
-            if (data.device && data.device.PowerState) {
+            // Test for the key, not its value. 2024+ Tizen firmware reports
+            // "on" when on, but off is reported as EITHER "standby" or an
+            // empty string -- observed decaying from one to the other the
+            // longer the set sits asleep. A truthiness check handles the
+            // former and misreads the latter as "no power state reported",
+            // falling through to the assume-on branch below. That is why the
+            // accessory tracks correctly right after power-off and sticks On
+            // some time later. Matches the `!== undefined` test device.js
+            // already uses to decide whether a TV reports power state at all.
+            if (data.device && data.device.PowerState !== undefined) {
                 return data.device.PowerState == 'on';
             }
 
+            // TV doesn't report power state at all -- trust the port check.
             return true;
         })
         .catch(() => fallback);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "directories": {
     "lib": "lib"
   },
+  "scripts": {
+    "test": "node --test"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tavicu/homebridge-samsung-tizen.git"

--- a/test/powerstate.test.js
+++ b/test/powerstate.test.js
@@ -1,0 +1,57 @@
+/**
+ * Power-state decoding in Base#getStateHttp.
+ *
+ * Run: node --test
+ *
+ * The case that matters is the empty string. 2024+ Tizen firmware reports
+ * "on" when the panel is on and "" in standby -- it never sends "standby" --
+ * and these sets keep port 8001 answering while asleep, so the port check
+ * can't catch it either. Upstream tested the value's truthiness, so standby
+ * fell through to the assume-on branch and the HomeKit tile stuck On forever.
+ */
+const test   = require('node:test');
+const assert = require('node:assert');
+const Base   = require('../lib/methods/base');
+
+function methodReporting(info) {
+    const device = {
+        config  : { ip: '127.0.0.1', mac: '00:00:00:00:00:00', name: 'Test TV' },
+        cache   : {},
+        storage : {},
+        emit    : () => true,
+        on      : () => {},
+        log     : { debug() {}, info() {}, warn() {}, error() {} }
+    };
+
+    const method = new Base(device);
+
+    method.getInfo = () => Promise.resolve(info);
+
+    return method;
+}
+
+test('PowerState "on" reads as on', async () => {
+    assert.equal(await methodReporting({ device: { PowerState: 'on' } }).getStateHttp(true), true);
+});
+
+test('empty PowerState is standby, not unknown', async () => {
+    assert.equal(await methodReporting({ device: { PowerState: '' } }).getStateHttp(true), false);
+});
+
+test('PowerState "standby" reads as off', async () => {
+    assert.equal(await methodReporting({ device: { PowerState: 'standby' } }).getStateHttp(true), false);
+});
+
+test('a TV that omits PowerState still trusts the port check', async () => {
+    assert.equal(await methodReporting({ device: {} }).getStateHttp(true), true);
+    assert.equal(await methodReporting({ device: {} }).getStateHttp(false), true);
+});
+
+test('an unreachable TV uses the fallback', async () => {
+    const method = methodReporting(null);
+
+    method.getInfo = () => Promise.reject(new Error('timeout'));
+
+    assert.equal(await method.getStateHttp(false), false);
+    assert.equal(await method.getStateHttp(true), true);
+});


### PR DESCRIPTION
Fixes the "TV always on" behaviour reported in #720 and #702.

### The bug

2024+ Tizen firmware reports `device.PowerState` as `"on"` when the panel is on. When the set is **off** it reports **either `"standby"` or an empty string** — the same state, reported differently depending on how long it has been asleep.

`getStateHttp()` tested the value's truthiness. That handles `"standby"` fine, but `""` is falsy, so it was read as "this TV doesn't report a power state" and fell through to the unconditional `return true`.

That asymmetry is, I think, the explanation for #702's title — *"**After some time**, TV appears to be on even if it's in standby"*. The accessory tracks correctly right after power-off, while the TV still says `"standby"`, and sticks On once the value decays to `""`. It also fits @Tontonpat's report in #720 of seeing `PowerState":""`, then `"standby"`, then blank again.

`getStatePing()` can't compensate on these sets: they keep 8001 (and 8002, 8080) answering while asleep, so the ping is always true and `getStateHttp()` is the only thing that can see standby.

### The change

One token — test for the key rather than its value:

```js
if (data.device && data.device.PowerState !== undefined) {
```

`lib/device.js` already uses `data.device.PowerState !== undefined` to set `storage.powerstate`, i.e. to decide whether a TV reports power state at all. The two files disagreed with each other, and that disagreement was the bug.

TVs that omit `PowerState` entirely are unaffected — they keep the existing ping fallback.

### Verification

Observed on two sets, 2026-08-17, polling `/api/v2/` directly:

| | off | on |
|---|---|---|
| QN75QN90FAFXZA (2025) | `''` ×13 over 12 min after a long sleep; `'standby'` immediately after power-off | `'on'` |
| UN43DU7200FXZA (2024) | `''` throughout | *(untouched control)* |

Both off-values compare unequal to `'on'`, so both now read as off.

Adds `test/powerstate.test.js` — `node --test`, no new dependencies, five cases. Against the unpatched `base.js` exactly one fails (the empty string); the other four pass either way, which is what shows the change is narrow.

### Not addressed here

`getInfo()` allows `this.timeout < 500 ? 500 : this.timeout`, so 500ms by default. While the TV is **on** it can take well over 6 seconds to answer `/api/v2/`, and those timeouts land in `.catch(() => fallback)`. That currently fails toward "on" so it largely masks itself, but it's worth a separate look. Left out to keep this diff to one line.