### PR TITLE
Fix the CANAL+ id and add eight apps confirmed on a 2024 French set

### DIFF
--- a/docs/extra/applications.md
+++ b/docs/extra/applications.md
@@ -66,7 +66,7 @@ Most of the IDs changed starting with year 2020. If you know your TV model is fr
 | Explore Google Assistant | `3202004020674`                                     |
 | Amazon Alexa             | `3202004020626`                                     |
 | My5                      | `121299000612`                                      |
-| SmartThings              | `3201710015016` / `3201910019378`                   |
+| SmartThings              | `3201710015016` / `3201910019378` / `3202311033054` |
 | BritBox                  | `3201909019175`                                     |
 | TikTok                   | `3202008021577`                                     |
 | RaiPlay                  | `111399002034`                                      |
@@ -97,6 +97,9 @@ Most of the IDs changed starting with year 2020. If you know your TV model is fr
 | Google Meet              | `3202008021439`                                     |
 | Kidoodle.TV              | `3201910019457`                                     |
 | Emby                     | `3201606009872`                                     |
+| Samsung TV Plus          | `3202405035480`                                     |
+| Amazon Luna              | `3202203026819`                                     |
+| Copilot                  | `3202503039231`                                     |
 | Pathe Thuis              | `3201506003175`                                     |
 | Canaal Digitaal          | `3201803015869`                                     |
 | NL Ziet                  | `3202012022421`                                     |
@@ -104,7 +107,7 @@ Most of the IDs changed starting with year 2020. If you know your TV model is fr
 | Kijk                     | `3201901017768`                                     |
 | Videoland                | `3201810017074`                                     |
 | Universal Guide          | `3201710015067`                                     |
-| CANAL+                   | `3201606009910`                                     |
+| CANAL+                   | `3201606009910` / `3202010022094`                   |
 | Molotov                  | `3201611011210`                                     |
 | OQEE by Free             | `3202103023185`                                     |
 | B.tv                     | `3201910019420`                                     |
@@ -115,6 +118,11 @@ Most of the IDs changed starting with year 2020. If you know your TV model is fr
 | ARTE                     | `3202011022316`                                     |
 | Benshi                   | `3202007021336`                                     |
 | france.tv                | `3202103023232`                                     |
+| TF1+                     | `3202209028524`                                     |
+| M6+                      | `3202207027908`                                     |
+| RMC BFM Play             | `3202303030351`                                     |
+| Pathe Home               | `3202311033030`                                     |
+| Orange TV                | `3202105023867`                                     |
 | Mako                     | `3201506003716`                                     |
 | Reshet13                 | `3201812017600`                                     |
 | Kan11                    | `3201803015997`                                     |


### PR DESCRIPTION
The CANAL+ id in the list answers 404 on a 2024 set, which is a costly kind of wrong: it looks
like the television is refusing rather than like the id being stale. The app was republished in
October 2020 as `3202010022094`. Both ids are kept, in the older-then-newer order the table
already uses, since the old one remains right for older firmware.

SmartThings gained a third id the same way: `3202311033054`.

Eight apps are added. Five go with the other French entries - TF1+, M6+, RMC BFM Play, Pathe Home
and Orange TV - and three with the international ones: Samsung TV Plus, Amazon Luna and Copilot.

## How these were obtained

Every id was confirmed on the television, not copied from elsewhere: a `GET` to
`http://<tv>:8001/api/v2/applications/<id>` answers with the app's own name and version when it is
installed, and 404 when it is not. Each id above came back with the name shown, and each app was
then launched and seen to open.

They were found by sweeping the id space rather than by guessing. The ids are structured - `320`,
then the year and month, then a six-digit sequence that climbs with time - so a month narrows to a
band rather than the whole space. Anchoring that curve on the dated ids already in lists like this
one turns the search into a few tens of thousands of requests per publication year, which is what
turned up CANAL+ at a sequence nobody had recorded.

## Two caveats worth stating

- These come from a French set (TQ65S95DATXXC, 2024). Samsung's catalogue is regional, so the
  French entries in particular may not hold elsewhere - which is the same warning this page
  already gives at the top, and it applies to what I am adding.
- An id that answers with a name is not always something that can be launched. Some entries the
  set answers for are destinations in its own interface: launching them navigates somewhere
  rather than opening an app. Everything added here was checked to open.